### PR TITLE
Update email field to allow submit instead of 500 error

### DIFF
--- a/functions/next-api/wordpress/gravityForms/processGfFieldValues.js
+++ b/functions/next-api/wordpress/gravityForms/processGfFieldValues.js
@@ -91,8 +91,10 @@ export default function processGfFieldValues(entryData, fieldData) {
         break
 
       case 'EmailField':
-        // TODO: As of WP GraphQL Gravity Forms v.0.4.1, this is accurate, but it appears it may be changing to a nested version in the next release: fieldValue.emailValues = { value, confirmationValue }.
-        fieldValue.value = entryData[fieldName]
+        fieldValue.emailValues = {
+          value: entryData[fieldName],
+          confirmationValue: entryData[fieldName]
+        }
         break
 
       case 'FileUploadField':


### PR DESCRIPTION
Closes #

### Description

This fixes the 500 error on submission of gravity forms.

### Verification

How will a stakeholder test this?

1. Have Gravity forms, WPGraphQL updates to most recent releases
2. Fill out a contact form with email 
3. Submit
